### PR TITLE
Refactor daily and command logic

### DIFF
--- a/src/commands/falseCommand.js
+++ b/src/commands/falseCommand.js
@@ -1,49 +1,28 @@
 import { app } from '../services/slackApp.js';
-import { ddbDoc } from '../services/dynamodb.js';
-import {GetCommand, PutCommand, UpdateCommand} from '@aws-sdk/lib-dynamodb';
+import { getQuestion, recordAnswer } from '../services/trivia.js';
 
 export function registerFalseCommand() {
-    app.command('/false', async ({ command, ack, respond, say }) => {
-        await ack();
-        const input = command.text.trim();
-        if (!['1', '2', '3'].includes(input)) {
-            await respond(`incorrect format. Please answer 1, 2, or 3.`);
-            return;
-        }
-        const dateKey = new Date().toISOString().split('T')[0];
+  app.command('/false', async ({ command, ack, respond, say }) => {
+    await ack();
+    const input = command.text.trim();
+    if (!['1', '2', '3'].includes(input)) {
+      await respond(`incorrect format. Please answer 1, 2, or 3.`);
+      return;
+    }
 
-        const res = await ddbDoc.send(
-            new GetCommand({
-                TableName: process.env.TABLE_NAME,
-                Key: {
-                    pk: `question:${dateKey}`
-                }
-            })
-        );
+    const dateKey = new Date().toISOString().split('T')[0];
+    const question = await getQuestion(dateKey);
 
-        const hasSubmitted = res.Item?.answers?.[command.user_id] !== undefined;
-        if (hasSubmitted) {
-            await respond("You've already submitted for today!");
-            return;
-        }
-        const isCorrect = res.Item?.correctAnswerIndex === parseInt(input) - 1;
-        await ddbDoc.send(
-            new UpdateCommand({
-                TableName: process.env.TABLE_NAME,
-                Key: {
-                    pk: `question:${dateKey}`,
-                },
-                UpdateExpression: "SET #answers.#userId = :correct",
-                ExpressionAttributeNames: {
-                    "#answers": "answers",
-                    "#userId": command.user_id,
-                },
-                ExpressionAttributeValues: {
-                    ":correct": isCorrect,
-                },
-            })
-        );
-        await respond(`You answered: ${input}`);
-        await say(`<@${command.user_id}> just locked in their answer!`);
-    });
+    const hasSubmitted = question?.answers?.[command.user_id] !== undefined;
+    if (hasSubmitted) {
+      await respond("You've already submitted for today!");
+      return;
+    }
+
+    const isCorrect = question?.correctAnswerIndex === parseInt(input) - 1;
+    await recordAnswer(dateKey, command.user_id, isCorrect);
+
+    await respond(`You answered: ${input}`);
+    await say(`<@${command.user_id}> just locked in their answer!`);
+  });
 }

--- a/src/handlers/dailyHandler.js
+++ b/src/handlers/dailyHandler.js
@@ -1,75 +1,73 @@
 import { app } from '../services/slackApp.js';
-import { openai } from '../services/openAI.js';
-import { zodTextFormat } from 'openai/helpers/zod';
-import { TriviaEvent } from '../utils/validation.js';
 import { ddbDoc } from '../services/dynamodb.js';
-import { GetCommand, PutCommand } from '@aws-sdk/lib-dynamodb';
+import { GetCommand } from '@aws-sdk/lib-dynamodb';
+import {
+  generateQuestion,
+  getQuestion,
+  storeQuestion,
+} from '../services/trivia.js';
 
 const DEFAULT_THEME = 'cats';
 
 export const daily = async () => {
-    const channel = 'C08V66J0Q03'; // todo maybe not hardcode this
-    const dateKey = new Date().toISOString().split('T')[0];
-    const yesterdayKey = new Date(Date.now() - 86400000).toISOString().split('T')[0];
+  const channel = 'C08V66J0Q03'; // todo maybe not hardcode this
+  const dateKey = new Date().toISOString().split('T')[0];
+  const yesterdayKey = new Date(Date.now() - 86400000)
+    .toISOString()
+    .split('T')[0];
 
-    const yesterdayQuestion = await ddbDoc.send(
-        new GetCommand({
-            TableName: process.env.TABLE_NAME,
-            Key: {
-                pk: `question:${yesterdayKey}`
-            },
-        })
-    );
+  const yesterdayRecord = await getQuestion(yesterdayKey);
+  if (yesterdayRecord) {
+    await postYesterdayResults(channel, yesterdayRecord);
+  }
 
-    if (yesterdayQuestion.Item) {
-        const record = yesterdayQuestion.Item;
-        await app.client.chat.postMessage({channel, text: `The answer for yesterday's question is: *${record.options[record.correctAnswerIndex]}*`});
-        await app.client.chat.postMessage({channel, text: `_${record.explanation}_`});
-        for (const userId in record.answers) {
-            const correct = record.answers[userId];
-            await app.client.chat.postMessage({channel, text: `<@${userId}> answered: ${correct ? '🟢' : '🔴'}`});
-        }
-        await app.client.chat.postMessage({channel, text: `-------------------------------`});
-    }
+  const res = await ddbDoc.send(
+    new GetCommand({
+      TableName: process.env.TABLE_NAME,
+      Key: { pk: channel },
+    }),
+  );
+  const theme = res.Item ? res.Item.theme : DEFAULT_THEME;
 
-    const res = await ddbDoc.send(
-        new GetCommand({
-            TableName: process.env.TABLE_NAME,
-            Key: { pk: channel },
-        })
-    );
-    const theme = res.Item ? res.Item.theme : DEFAULT_THEME;
+  const trivia = await generateQuestion(theme);
+  await storeQuestion(dateKey, trivia, theme);
 
-    const response = await openai.responses.parse({
-        model: 'gpt-4.1',
-        input: [
-            { role: 'system', content: 'You are a trivia master creating questions for the game: Two Truths and a Lie. Do not make the answers too obvious, and ensure the correct answer has a random placement among the options.' },
-            {
-                role: 'user',
-                content: `Generate a trivia question about ${theme}. Return exactly two true statements and one false and explain why.`,
-            },
-        ],
-        text: {
-            format: zodTextFormat(TriviaEvent, 'event'),
-        },
-    });
-    const trivia = TriviaEvent.parse(JSON.parse(response.output_text));
-    await ddbDoc.send(
-        new PutCommand({
-            TableName: process.env.TABLE_NAME,
-            Item: {
-                pk: `question:${dateKey}`,
-                ...trivia,
-                theme,
-                answers: {},
-            },
-        })
-    );
-    await app.client.chat.postMessage({ channel, text: `Here is your daily trivia question for *${new Date().toISOString().split('T')[0]}*:` });
-    await app.client.chat.postMessage({ channel, text: `*Which of the following statements about ${theme.toLowerCase()} is NOT true?*` });
-    await app.client.chat.postMessage({ channel, text: `*1)* ${trivia.options[0]}` });
-    await app.client.chat.postMessage({ channel, text: `*2)* ${trivia.options[1]}` });
-    await app.client.chat.postMessage({ channel, text: `*3)* ${trivia.options[2]}` });
-    await app.client.chat.postMessage({ channel, text: `_Type /false 1, 2 or 3 into the channel to submit (you can only submit your answer once)_` });
-    return { statusCode: 200, body: 'OK' };
+  await postTriviaQuestion(channel, trivia, theme);
+  return { statusCode: 200, body: 'OK' };
 };
+
+async function postYesterdayResults(channel, record) {
+  await app.client.chat.postMessage({
+    channel,
+    text: `The answer for yesterday's question is: *${record.options[record.correctAnswerIndex]}*`,
+  });
+  await app.client.chat.postMessage({ channel, text: `_${record.explanation}_` });
+  for (const userId in record.answers) {
+    const correct = record.answers[userId];
+    await app.client.chat.postMessage({
+      channel,
+      text: `<@${userId}> answered: ${correct ? '🟢' : '🔴'}`,
+    });
+  }
+  await app.client.chat.postMessage({ channel, text: '----------------------------' });
+}
+
+async function postTriviaQuestion(channel, trivia, theme) {
+  await app.client.chat.postMessage({
+    channel,
+    text: `Here is your daily trivia question for *${new Date()
+      .toISOString()
+      .split('T')[0]}*:`,
+  });
+  await app.client.chat.postMessage({
+    channel,
+    text: `*Which of the following statements about ${theme.toLowerCase()} is NOT true?*`,
+  });
+  await app.client.chat.postMessage({ channel, text: `*1)* ${trivia.options[0]}` });
+  await app.client.chat.postMessage({ channel, text: `*2)* ${trivia.options[1]}` });
+  await app.client.chat.postMessage({ channel, text: `*3)* ${trivia.options[2]}` });
+  await app.client.chat.postMessage({
+    channel,
+    text: '_Type /false 1, 2 or 3 into the channel to submit (you can only submit your answer once)_',
+  });
+}

--- a/src/services/trivia.js
+++ b/src/services/trivia.js
@@ -1,0 +1,76 @@
+import { ddbDoc } from './dynamodb.js';
+import { openai } from './openAI.js';
+import { zodTextFormat } from 'openai/helpers/zod';
+import { TriviaEvent } from '../utils/validation.js';
+import { GetCommand, PutCommand, UpdateCommand } from '@aws-sdk/lib-dynamodb';
+
+export async function getQuestion(dateKey) {
+  const res = await ddbDoc.send(new GetCommand({
+    TableName: process.env.TABLE_NAME,
+    Key: { pk: `question:${dateKey}` },
+  }));
+  return res.Item;
+}
+
+export async function storeQuestion(dateKey, trivia, theme) {
+  await ddbDoc.send(new PutCommand({
+    TableName: process.env.TABLE_NAME,
+    Item: {
+      pk: `question:${dateKey}`,
+      ...trivia,
+      theme,
+      answers: {},
+    },
+  }));
+}
+
+export async function recordAnswer(dateKey, userId, isCorrect) {
+  await ddbDoc.send(new UpdateCommand({
+    TableName: process.env.TABLE_NAME,
+    Key: { pk: `question:${dateKey}` },
+    UpdateExpression: 'SET #answers.#userId = :correct',
+    ExpressionAttributeNames: {
+      '#answers': 'answers',
+      '#userId': userId,
+    },
+    ExpressionAttributeValues: {
+      ':correct': isCorrect,
+    },
+  }));
+}
+
+export async function generateQuestion(theme) {
+  const response = await openai.responses.parse({
+    model: 'gpt-4.1',
+    input: [
+      { role: 'system', content: 'You are a trivia master creating questions for the game: Two Truths and a Lie. Do not make the answers too obvious, and ensure the correct answer has a random placement among the options.' },
+      {
+        role: 'user',
+        content: `Generate a trivia question about ${theme}. Return exactly two true statements and one false and explain why.`,
+      },
+    ],
+    text: {
+      format: zodTextFormat(TriviaEvent, 'event'),
+    },
+  });
+  return TriviaEvent.parse(JSON.parse(response.output_text));
+}
+
+export async function getTheme(channel) {
+  const res = await ddbDoc.send(new GetCommand({
+    TableName: process.env.TABLE_NAME,
+    Key: { pk: channel },
+  }));
+  return res.Item ? res.Item.theme : null;
+}
+
+export async function setTheme(channel, theme) {
+  await ddbDoc.send(new PutCommand({
+    TableName: process.env.TABLE_NAME,
+    Item: {
+      pk: channel,
+      theme,
+      updatedAt: new Date().toISOString(),
+    },
+  }));
+}


### PR DESCRIPTION
## Summary
- centralize trivia DB helpers and OpenAI call in `trivia.js`
- simplify daily handler using new helpers
- shorten `/false` and `/theme` commands

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6841c8031f64832e961cfea9d9b1216e