### PR TITLE
Implement weekly scoring

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -33,6 +33,14 @@ functions:
           rate:
             - cron(0 0/4 ? * MON-FRI *) # todo 08:00 every day monday to friday
           timezone: Europe/Copenhagen
+  weekly:
+    handler: src/handlers/weeklyHandler.weekly
+    events:
+      - schedule:
+          method: scheduler
+          rate:
+            - cron(0 9 ? * SAT *)
+          timezone: Europe/Copenhagen
 resources:
   Resources:
     MyTable:

--- a/src/handlers/weeklyHandler.js
+++ b/src/handlers/weeklyHandler.js
@@ -1,0 +1,34 @@
+import { app } from '../services/slackApp.js';
+import { getWeeklyScores } from '../services/trivia.js';
+
+export const weekly = async () => {
+  const channel = 'C08V66J0Q03';
+  const today = new Date();
+  const scores = await getWeeklyScores(today);
+  const entries = Object.entries(scores);
+  if (entries.length === 0) {
+    await app.client.chat.postMessage({
+      channel,
+      text: 'No trivia results recorded this week.',
+    });
+    return { statusCode: 200, body: 'OK' };
+  }
+
+  entries.sort((a, b) => b[1] - a[1]);
+  const best = entries[0][1];
+  const winners = entries.filter(([, s]) => s === best).map(([u]) => `<@${u}>`);
+
+  await app.client.chat.postMessage({ channel, text: '*Weekly Trivia Results*' });
+  for (const [userId, score] of entries) {
+    await app.client.chat.postMessage({
+      channel,
+      text: `<@${userId}>: ${score}`,
+    });
+  }
+  await app.client.chat.postMessage({
+    channel,
+    text: `:trophy: Winner${winners.length > 1 ? 's' : ''}: ${winners.join(', ')}`,
+  });
+  await app.client.chat.postMessage({ channel, text: '----------------------' });
+  return { statusCode: 200, body: 'OK' };
+};

--- a/src/services/trivia.js
+++ b/src/services/trivia.js
@@ -4,6 +4,15 @@ import { zodTextFormat } from 'openai/helpers/zod';
 import { TriviaEvent } from '../utils/validation.js';
 import { GetCommand, PutCommand, UpdateCommand } from '@aws-sdk/lib-dynamodb';
 
+function weekStart(dateInput) {
+  const d = new Date(dateInput);
+  const day = d.getDay();
+  const diff = d.getDate() - day + (day === 0 ? -6 : 1); // adjust when day is sunday
+  const monday = new Date(d);
+  monday.setDate(diff);
+  return monday.toISOString().split('T')[0];
+}
+
 export async function getQuestion(dateKey) {
   const res = await ddbDoc.send(new GetCommand({
     TableName: process.env.TABLE_NAME,
@@ -37,6 +46,26 @@ export async function recordAnswer(dateKey, userId, isCorrect) {
       ':correct': isCorrect,
     },
   }));
+
+  if (isCorrect) {
+    const weekKey = weekStart(dateKey);
+    await ddbDoc.send(
+      new UpdateCommand({
+        TableName: process.env.TABLE_NAME,
+        Key: { pk: `score:${weekKey}` },
+        UpdateExpression:
+          'SET #scores.#userId = if_not_exists(#scores.#userId, :zero) + :one',
+        ExpressionAttributeNames: {
+          '#scores': 'scores',
+          '#userId': userId,
+        },
+        ExpressionAttributeValues: {
+          ':one': 1,
+          ':zero': 0,
+        },
+      }),
+    );
+  }
 }
 
 export async function generateQuestion(theme) {
@@ -74,4 +103,15 @@ export async function setTheme(channel, theme) {
       updatedAt: new Date().toISOString(),
     },
   }));
+}
+
+export async function getWeeklyScores(dateInput) {
+  const weekKey = weekStart(dateInput);
+  const res = await ddbDoc.send(
+    new GetCommand({
+      TableName: process.env.TABLE_NAME,
+      Key: { pk: `score:${weekKey}` },
+    }),
+  );
+  return res.Item ? res.Item.scores || {} : {};
 }


### PR DESCRIPTION
## Summary
- update serverless config and add weekly handler
- track user scores per week when recording answers
- display weekly results every Saturday

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6841cddcac78832e82fad7fbca9360f6