### PR TITLE
Update trivia flow for weekly generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
 # Slack Trivia Bot
 
-Quick and dirty implementation of a Slack bot that can run a trivia game. Might clean up at some point ¯\\\_(ツ)_/¯.
+Quick and dirty implementation of a Slack bot that can run a trivia game. Might clean up at some point ¯\\_(ツ)_/¯.
+
+## Schedule
+
+- **Monday** – generate trivia questions for the entire work week based on the current theme and ask Monday's question.
+- **Tuesday–Friday** – ask the prepared question for the day and reveal yesterday's answer.
+- **Saturday** – reveal Friday's answer and announce the weekly winner.

--- a/src/handlers/weeklyHandler.js
+++ b/src/handlers/weeklyHandler.js
@@ -1,9 +1,17 @@
 import { app } from '../services/slackApp.js';
-import { getWeeklyScores } from '../services/trivia.js';
+import { getWeeklyScores, getQuestion } from '../services/trivia.js';
+import { postYesterdayResults } from './dailyHandler.js';
 
 export const weekly = async () => {
   const channel = process.env.SLACK_CHANNEL_ID;
   const today = new Date();
+  const yesterdayKey = new Date(today.getTime() - 86400000)
+    .toISOString()
+    .split('T')[0];
+  const yesterdayRecord = await getQuestion(yesterdayKey);
+  if (yesterdayRecord) {
+    await postYesterdayResults(channel, yesterdayRecord);
+  }
   const entries = await getWeeklyScores(today);
   if (entries.length === 0) {
     await app.client.chat.postMessage({

--- a/src/utils/validation.js
+++ b/src/utils/validation.js
@@ -5,3 +5,5 @@ export const TriviaEvent = z.object({
   correctAnswerIndex: z.number(),
   explanation: z.string(),
 });
+
+export const TriviaWeek = z.array(TriviaEvent).length(5);


### PR DESCRIPTION
## Summary
- generate 5 questions at once for the week
- factor Monday logic into a helper
- parse arrays of trivia questions

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6843ee56ea08832eb0e9ca4d007ea117