### PR TITLE
Add /reveal command

### DIFF
--- a/src/commands/revealCommand.js
+++ b/src/commands/revealCommand.js
@@ -1,0 +1,15 @@
+import { app } from '../services/slackApp.js';
+import { postTodaysResults } from '../handlers/dailyHandler.js';
+
+export function registerRevealCommand() {
+  app.command('/reveal', async ({ ack, respond }) => {
+    await ack();
+    try {
+      await postTodaysResults();
+      await respond("Revealing today's answer to the channel...");
+    } catch (err) {
+      console.error('Reveal command failed', err);
+      await respond("Sorry, I couldn't reveal the answer.");
+    }
+  });
+}

--- a/src/handlers/dailyHandler.js
+++ b/src/handlers/dailyHandler.js
@@ -26,29 +26,41 @@ export const daily = async () => {
   return { statusCode: 200, body: 'OK' };
 };
 
+async function postResults(dateKey, heading) {
+  const question = await getQuestion(dateKey);
+  if (!question) {
+    return;
+  }
+
+  const lines = [
+    heading,
+    `*${question.correctAnswerIndex + 1}) ${question.options[question.correctAnswerIndex]}*`,
+    `_${question.explanation}_`,
+  ];
+
+  for (const userId in question.answers) {
+    const correct = question.answers[userId];
+    lines.push(`<@${userId}> ${correct ? '🟢' : '🔴'}`);
+  }
+  lines.push('----------------------------');
+
+  await app.client.chat.postMessage({
+    channel: process.env.SLACK_CHANNEL_ID,
+    text: lines.join('\n'),
+  });
+}
+
 export async function postYesterdayResults() {
   const today = new Date();
   const yesterdayKey = new Date(today.getTime() - 86400000)
       .toISOString()
       .split('T')[0];
-  const yesterdayQuestion = await getQuestion(yesterdayKey);
-  if (!yesterdayQuestion) {
-    return;
-  }
-  const lines = [
-    'Yesterdays answer:',
-    `*${yesterdayQuestion.correctAnswerIndex + 1}) ${yesterdayQuestion.options[yesterdayQuestion.correctAnswerIndex]}*`,
-    `_${yesterdayQuestion.explanation}_`,
-  ];
-  for (const userId in yesterdayQuestion.answers) {
-    const correct = yesterdayQuestion.answers[userId];
-    lines.push(`<@${userId}> ${correct ? '🟢' : '🔴'}`);
-  }
-  lines.push('----------------------------');
-  await app.client.chat.postMessage({
-    channel: process.env.SLACK_CHANNEL_ID,
-    text: lines.join('\n'),
-  });
+  await postResults(yesterdayKey, "Yesterdays answer:");
+}
+
+export async function postTodaysResults() {
+  const todayKey = new Date().toISOString().split('T')[0];
+  await postResults(todayKey, "Today's answer:");
 }
 
 export async function postTriviaQuestion() {

--- a/src/handlers/slackHandler.js
+++ b/src/handlers/slackHandler.js
@@ -1,9 +1,11 @@
 import { awsLambdaReceiver } from '../services/slackApp.js';
 import { registerLieCommand } from '../commands/lieCommand.js';
 import { registerThemeCommand } from '../commands/themeCommand.js';
+import { registerRevealCommand } from '../commands/revealCommand.js';
 
 registerLieCommand();
 registerThemeCommand();
+registerRevealCommand();
 
 export const handler = async (event, context, callback) => {
   const handler = await awsLambdaReceiver.start();


### PR DESCRIPTION
## Summary
- implement `/reveal` slash command
- register the command with the Slack handler
- share logic for posting daily and yesterday results
- revert README changes

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68505bac42d0832ea6dafe0a0cb46503