### PR TITLE
Implement winner history tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,5 +5,12 @@ Quick and dirty implementation of a Slack bot that can run a trivia game. Messy 
 
 - **Monday** – generate trivia questions for the entire work week based on the current theme
 - **Monday-Friday** - ask question in trivia channel
-- **Tuesday–Saturday – reveal yesterday's answer
+- **Tuesday–Saturday** – reveal yesterday's answer
 - **Saturday** – announce the weekly winner.
+
+## Commands
+
+- `/theme [new theme]` – set or show the trivia theme
+- `/lie <1|2|3>` – submit today's answer
+- `/reveal` – show today's correct answer
+- `/winners` – list previous weekly winners and the theme they won with

--- a/src/commands/winnersCommand.js
+++ b/src/commands/winnersCommand.js
@@ -1,0 +1,24 @@
+import { app } from '../services/slackApp.js';
+import { getWinnersHistory } from '../services/trivia.js';
+
+export function registerWinnersCommand() {
+  app.command('/winners', async ({ ack, respond }) => {
+    await ack();
+    const history = await getWinnersHistory();
+    const weekKeys = Object.keys(history).sort();
+    if (weekKeys.length === 0) {
+      await respond('No winners have been recorded yet.');
+      return;
+    }
+
+    const lines = ['*Past Winners*'];
+    for (const wk of weekKeys) {
+      const entry = history[wk];
+      const winners = (entry.winners || []).map(id => `<@${id}>`).join(', ');
+      lines.push(`${wk} – ${entry.theme || 'unknown'} – ${winners}`);
+    }
+
+    await respond(lines.join('\n'));
+  });
+}
+

--- a/src/handlers/dailyHandler.js
+++ b/src/handlers/dailyHandler.js
@@ -1,9 +1,11 @@
 import { app } from '../services/slackApp.js';
 import {
   generateWeekQuestions,
-  getQuestion, getWeeklyScores,
+  getQuestion,
+  getWeeklyScores,
   storeQuestion,
   weekStart,
+  recordWeeklyWinners,
 } from '../services/trivia.js';
 import {getTheme} from "../services/theme.js";
 
@@ -118,9 +120,14 @@ export async function postWeeklyResults() {
   entries.sort((a, b) => b[1].score - a[1].score);
 
   const bestScore = entries[0][1].score;
-  const winners = entries
-      .filter(([, data]) => data.score === bestScore)
-      .map(([userId]) => `<@${userId}>`);
+  const winnerEntries = entries.filter(([, data]) => data.score === bestScore);
+  const winners = winnerEntries.map(([userId]) => `<@${userId}>`);
+
+  const weekKey = weekStart();
+  const mondayQuestion = await getQuestion(weekKey);
+  const theme = mondayQuestion?.theme;
+  const winnerIds = winnerEntries.map(([userId]) => userId);
+  await recordWeeklyWinners(weekKey, winnerIds, theme);
 
   const lines = ['*Weekly results*'];
 

--- a/src/handlers/slackHandler.js
+++ b/src/handlers/slackHandler.js
@@ -2,10 +2,12 @@ import { awsLambdaReceiver } from '../services/slackApp.js';
 import { registerLieCommand } from '../commands/lieCommand.js';
 import { registerThemeCommand } from '../commands/themeCommand.js';
 import { registerRevealCommand } from '../commands/revealCommand.js';
+import { registerWinnersCommand } from '../commands/winnersCommand.js';
 
 registerLieCommand();
 registerThemeCommand();
 registerRevealCommand();
+registerWinnersCommand();
 
 export const handler = async (event, context, callback) => {
   const handler = await awsLambdaReceiver.start();

--- a/src/services/trivia.js
+++ b/src/services/trivia.js
@@ -133,3 +133,31 @@ export async function getWeeklyScores() {
     }
     return resultEntries;
 }
+
+export async function recordWeeklyWinners(weekKey, winners, theme) {
+    await ddbDoc.send(
+        new UpdateCommand({
+            TableName: process.env.TABLE_NAME,
+            Key: { pk: 'winners' },
+            UpdateExpression: 'SET #w.#wk = :val',
+            ExpressionAttributeNames: {
+                '#w': 'weeks',
+                '#wk': weekKey,
+            },
+            ExpressionAttributeValues: {
+                ':val': { winners, theme },
+            },
+        })
+    );
+}
+
+export async function getWinnersHistory() {
+    const res = await ddbDoc.send(
+        new GetCommand({
+            TableName: process.env.TABLE_NAME,
+            Key: { pk: 'winners' },
+        })
+    );
+    return res.Item ? res.Item.weeks || {} : {};
+}
+


### PR DESCRIPTION
## Summary
- track weekly winners in DynamoDB
- provide `/winners` command to list past winners
- record weekly winners after posting results
- register the new command
- document bot commands

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6887527241ec832e8eaed3da37f0918f